### PR TITLE
Remove labels' background color for the session list

### DIFF
--- a/NIMKit/NIMKit/Classes/Sections/SessionList/View/NIMSessionListCell.m
+++ b/NIMKit/NIMKit/Classes/Sections/SessionList/View/NIMSessionListCell.m
@@ -21,18 +21,15 @@
         [self addSubview:_avatarImageView];
         
         _nameLabel = [[UILabel alloc] initWithFrame:CGRectZero];
-        _nameLabel.backgroundColor = [UIColor whiteColor];
         _nameLabel.font            = [UIFont systemFontOfSize:15.f];
         [self addSubview:_nameLabel];
         
         _messageLabel = [[UILabel alloc] initWithFrame:CGRectZero];
-        _messageLabel.backgroundColor = [UIColor whiteColor];
         _messageLabel.font            = [UIFont systemFontOfSize:14.f];
         _messageLabel.textColor       = [UIColor lightGrayColor];
         [self addSubview:_messageLabel];
         
         _timeLabel = [[UILabel alloc] initWithFrame:CGRectZero];
-        _timeLabel.backgroundColor = [UIColor whiteColor];
         _timeLabel.font            = [UIFont systemFontOfSize:14.f];
         _timeLabel.textColor       = [UIColor lightGrayColor];
         [self addSubview:_timeLabel];


### PR DESCRIPTION
https://github.com/netease-im/NIM_iOS_UIKit/pull/245
移除消息列表中各 Label 的白色背景色。

![image](https://user-images.githubusercontent.com/526008/68729369-c56b4980-0604-11ea-897b-0da70f669a76.png)

![image](https://user-images.githubusercontent.com/526008/68729420-edf34380-0604-11ea-9f6c-76ce357744e6.png)
